### PR TITLE
fix(typescript): add types field in exports to fix declaration file bug for TS >= 4.7 w/ moduleResolution: 'nodenext'

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   "main": "edition-es2019/index.js",
   "exports": {
     "node": {
+      "types": "./compiled-types/index.d.ts",
       "import": "./edition-es2019-esm/index.js",
       "require": "./edition-es2019/index.js"
     }


### PR DESCRIPTION
fix https://github.com/bevry/filedirname/issues/224